### PR TITLE
Fix the carbs bars and the reportet carbs for treatments

### DIFF
--- a/lib/src/forms/print-daily-graphic.dart
+++ b/lib/src/forms/print-daily-graphic.dart
@@ -200,7 +200,7 @@ class PrintDailyGraphic extends BasePrint
           "x1": cm(x),
           "y1": cm(y),
           "x2": cm(x),
-          "y2": cm(graphHeight),
+          "y2": cm(graphHeight-lw),
           "lineColor": colCarbs,
           "lineWidth": cm(0.1),
         });

--- a/lib/src/jsonData.dart
+++ b/lib/src/jsonData.dart
@@ -535,8 +535,7 @@ class TreatmentData extends JsonData
     switch (eventType.toLowerCase())
     {
       case "bolus wizard":
-        if (boluscalc != null && boluscalc.carbs != null)return boluscalc.carbs;
-        else if (_carbs != null)return _carbs;
+        if (_carbs != null)return _carbs;
         break;
       case "meal bolus":
         if (_carbs != null)return _carbs;


### PR DESCRIPTION
The carbs bars now start directly above the x-axis.

Don't use the carbs entry from the bolus calculator. This will cause doubled carbs if they were added as seperate entry.